### PR TITLE
#3: Fix CPU cycle loop

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -22,12 +22,12 @@ Records all security-related events:
 
 **Random Content Serving** (when `hijinx_serve_random_content` is enabled)
 ```
-2025-12-18 10:22:45 - 10.0.0.50 - Served random content (file #2) - /wp-login.php
+2025-12-18 10:22:45 - 10.0.0.50 - Served random content (file #2) - /wp-login.php | GET /wp-login.php HTTP/1.1 200
 ```
 
 **Format**:
 ```
-TIMESTAMP - IP_ADDRESS - EVENT_TYPE - REQUEST_URI
+TIMESTAMP - IP_ADDRESS - EVENT_TYPE - REQUEST_URI | METHOD URI PROTOCOL STATUS
 ```
 
 ### hijinx-error.log - Error Log
@@ -84,8 +84,11 @@ When fake HTML is served:
 - **IP Address**: Who requested
 - **File Index**: Which HTML file was served (0-based index)
 - **URI**: What path was requested
+- **Original Request**: The complete request line in access.log format (METHOD URI PROTOCOL STATUS)
 
 Example: `file #2` means the 3rd HTML file (0-indexed) was served
+
+The log entry includes both what was served and the original request details, allowing you to correlate the fake response with the actual request made.
 
 ### Error Event
 


### PR DESCRIPTION
The CPU cycling issue was due to how we were returning responses before the content phase. After adjusting that cycles are down to normal.

This also addresses log formatting so that the original request is present in the Hijinx.log as well.